### PR TITLE
Fix: modified buffer not work

### DIFF
--- a/go-complete.el
+++ b/go-complete.el
@@ -52,6 +52,7 @@
 			     nil
 			     "-f=emacs"
 			     "autocomplete"
+			     buffer-file-name
 			     (concat "c" (int-to-string (-  (point) 1))))
       (call-process-region
        (point-min)

--- a/go-complete.el
+++ b/go-complete.el
@@ -56,7 +56,7 @@
       (call-process-region
        (point-min)
        (point-min)
-       "gocode"
+       go-complete-gocode-command
        nil
        temp-buffer
        nil


### PR DESCRIPTION
Modified buffer doesn't work for [gocode (Go Modules Version)](https://github.com/stamblerre/gocode), and it worked after add <path> param for command `autocomplete [<path>] <offset>`